### PR TITLE
Read in UTF-8

### DIFF
--- a/lib/dominion/domain_name.rb
+++ b/lib/dominion/domain_name.rb
@@ -13,7 +13,7 @@ module Dominion
 
     # takes the path to a rule file in the format defined in http://publicsuffix.org/format/
     def self.load_rules_from_file(path)
-      rules open(path).lines.reject { |s| s =~ %r[\A\s*(//.*)?\Z\n?] }.map { |s| DomainSuffixRule.new(s) }.sort << DomainSuffixRule.new("*")
+      rules open(path, "r:UTF-8").lines.reject { |s| s =~ %r[\A\s*(//.*)?\Z\n?] }.map { |s| DomainSuffixRule.new(s) }.sort << DomainSuffixRule.new("*")
     end
 
     # takes a domain string as argument; i.e. the hostname part of a URL


### PR DESCRIPTION
We ran into this problem deploying core in a cloud. Unless the operation Ruby version is already expecting UTF-8 then this can fail unless the global `Encoding` has been set. Dominion always uses a predefined file which always contains UTF-8 characters, so including this hint seems to have merit.

Thoughts?
