### PR TITLE
Use IO#readlines method instead of IO#lines

### DIFF
--- a/lib/dominion/domain_name.rb
+++ b/lib/dominion/domain_name.rb
@@ -13,7 +13,10 @@ module Dominion
 
     # takes the path to a rule file in the format defined in http://publicsuffix.org/list/
     def self.load_rules_from_file(path)
-      rules open(path, "r:UTF-8").lines.reject { |s| s =~ %r[\A\s*(//.*)?\Z\n?] }.map { |s| DomainSuffixRule.new(s) }.sort << DomainSuffixRule.new("*")
+      rules open(path, "r:UTF-8").readlines.
+        reject { |s| s =~ %r[\A\s*(//.*)?\Z\n?] }.
+        map { |s| DomainSuffixRule.new(s) }.
+        sort << DomainSuffixRule.new("*")
     end
 
     # takes a domain string as argument; i.e. the hostname part of a URL


### PR DESCRIPTION
- Ruby has deprecated the IO#lines method:

> IO#lines is deprecated; use #each_line instead

No tests, so I verified it still works locally based off the README examples.
